### PR TITLE
Add support for multiple IdPs

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,9 +30,10 @@ Role Variables
 The directory where the keypair and IdP metdata is stored.
 
 
-    mellon_sp_remote_idp_metadata_url: "https://idp.unilely.nl/saml2/idp/metadata.php"
+    mellon_sp_remote_idp_metadata_url:
+      - "https://idp.unilely.nl/saml2/idp/metadata.php"
 
-The URL from where to fetch the IdP metadata. 
+A list of URLs from where to fetch the IdP metadata. 
 
 
 Dependencies

--- a/tasks/mellon_sp.yml
+++ b/tasks/mellon_sp.yml
@@ -28,9 +28,28 @@
     dest: "{{ mellon_sp_cfg_dir }}/sp.crt"
 
 
-- name: Fetch IdP metadata from "{{ mellon_sp_remote_idp_metadata_url }}"
+- name: Change IdP metadata string to list
+  set_fact:
+    mellon_sp_remote_idp_metadata_url:
+      - "{{ mellon_sp_remote_idp_metadata_url }}"
+  when: mellon_sp_remote_idp_metadata_url is string
+  tags: idpmeta
+
+- name: Fetch IdP metadata from one source
   get_url:
-    url: "{{ mellon_sp_remote_idp_metadata_url }}"
+    url: "{{ mellon_sp_remote_idp_metadata_url[0] }}"
     dest: "{{ mellon_sp_cfg_dir }}/idp.xml"
     force: yes
+  when: mellon_sp_remote_idp_metadata_url | length == 1
+  tags: idpmeta
+
+- name: Fetch IdP metadata from multiple sources
+  get_url:
+    url: "{{ item }}"
+    dest: "{{ mellon_sp_cfg_dir }}/idp_{{ idx }}.xml"
+    force: yes
+  loop: "{{ mellon_sp_remote_idp_metadata_url }}"
+  loop_control:
+    index_var: idx
+  when: mellon_sp_remote_idp_metadata_url | length > 1
   tags: idpmeta


### PR DESCRIPTION
In some cases we might want to authenticate against different IdPs for
diffent resources behind the SP. In order to be able to fetch metadata
from more than one source, we need to turn the variable
mellon_sp_remote_idp_metadata_url from a string to a list.

If a string is provided or a list of one feed then the metadata will be
downloaded as idp.xml ensuring backwards compatibility. If more than one
feeds are in the list then each feed will be downladed as idp_X.xml