### PR TITLE
Simplify IdP metadata logic

### DIFF
--- a/tasks/mellon_sp.yml
+++ b/tasks/mellon_sp.yml
@@ -27,29 +27,13 @@
     content: "{{ mellon_sp_crt }}"
     dest: "{{ mellon_sp_cfg_dir }}/sp.crt"
 
-
-- name: Change IdP metadata string to list
-  set_fact:
-    mellon_sp_remote_idp_metadata_url:
-      - "{{ mellon_sp_remote_idp_metadata_url }}"
-  when: mellon_sp_remote_idp_metadata_url is string
-  tags: idpmeta
-
-- name: Fetch IdP metadata from one source
-  get_url:
-    url: "{{ mellon_sp_remote_idp_metadata_url[0] }}"
-    dest: "{{ mellon_sp_cfg_dir }}/idp.xml"
-    force: yes
-  when: mellon_sp_remote_idp_metadata_url | length == 1
-  tags: idpmeta
-
-- name: Fetch IdP metadata from multiple sources
+- name: Fetch IdP metadata
   get_url:
     url: "{{ item }}"
-    dest: "{{ mellon_sp_cfg_dir }}/idp_{{ idx }}.xml"
+    dest: "{{ mellon_sp_cfg_dir }}/idp{{ (mellon_sp_remote_idp_metadata_url is string) | ternary('', '_' ~ idx) }}.xml"
     force: yes
-  loop: "{{ mellon_sp_remote_idp_metadata_url }}"
+  # https://jmespath.org/specification.html#to-array
+  loop: "{{ mellon_sp_remote_idp_metadata_url | json_query('to_array(@)') }}"
   loop_control:
     index_var: idx
-  when: mellon_sp_remote_idp_metadata_url | length > 1
   tags: idpmeta

--- a/tasks/mellon_sp.yml
+++ b/tasks/mellon_sp.yml
@@ -35,5 +35,6 @@
   # https://jmespath.org/specification.html#to-array
   loop: "{{ mellon_sp_remote_idp_metadata_url | json_query('to_array(@)') }}"
   loop_control:
+    label: "{{ item }} => {{ mellon_sp_cfg_dir }}/idp{{ (mellon_sp_remote_idp_metadata_url is string) | ternary('', '_' ~ idx) }}.xml"
     index_var: idx
   tags: idpmeta


### PR DESCRIPTION
* Replace the 3 tasks that do string/list swapping with a single task that uses the jmespath [`to_array` filter](https://jmespath.org/specification.html#to-array)
* Improve loop label to display both the URL and the destination file:
   ```
   TASK [ansible-role-mellon_sp : Fetch IdP metadata] ****************************************
   ok: [www1] => (item=https://proxy.unimaas.edu/meta.xml => /etc/apache2/mellon/idp_0.xml)
   ok: [www1] => (item=https://proxy.uvt.edu/meta.xml => /etc/apache2/mellon/idp_1.xml)
   ```